### PR TITLE
[Closes #3] Update LLM.swift package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1cae05248259402243842ebd22f702ab3aff1be4fccf8ab6f5d5491b302429b7",
+  "originHash" : "718aa994700ee72192ec813dba021aebd26a56ee1088fb90294e02180d82f4cb",
   "pins" : [
     {
       "identity" : "aws-crt-swift",
@@ -20,20 +20,12 @@
       }
     },
     {
-      "identity" : "llama.cpp",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ggerganov/llama.cpp/",
-      "state" : {
-        "revision" : "cda0e4b648dde8fac162b3430b14a99597d3d74f"
-      }
-    },
-    {
       "identity" : "llm.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eastriverlee/LLM.swift",
       "state" : {
-        "branch" : "pinned",
-        "revision" : "48546489c46c8d116a320ad6bc031bbd714fd8c0"
+        "branch" : "main",
+        "revision" : "7584d0736fce6ec032ab357ee63a8e7b00c64d96"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "LLMKit",
     platforms: [
-            .iOS(.v15)
+        .macOS(.v14),
+        .iOS(.v15),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -15,7 +16,7 @@ let package = Package(
             targets: ["LLMKit", "LLMKitAWSBedrock", "LLMKitLlama"])
     ],
     dependencies: [
-        .package(url: "https://github.com/eastriverlee/LLM.swift", branch: "pinned"),
+        .package(url: "https://github.com/eastriverlee/LLM.swift", branch: "main"),
         .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "1.0.0")
     ],
     targets: [

--- a/Sources/LLMKitLlama/LlamaBot.swift
+++ b/Sources/LLMKitLlama/LlamaBot.swift
@@ -19,8 +19,8 @@ open class LlamaBot: Bot {
     private var subscription: AnyCancellable?
     
     required public init?(model: LLMKit.Model) {
-        if let downloadedURL = model.downloadedURL {
-            llm = LLM(from: downloadedURL, template: model.template, maxTokenCount: model.maxTokenCount)
+        if let downloadedURL = model.downloadedURL, let llm = LLM(from: downloadedURL, template: model.template, maxTokenCount: model.maxTokenCount) {
+            self.llm = llm
             super.init(model: model)
             subscription = llm.objectWillChange.sink { [weak self] in
                 guard let self = self else { return }


### PR DESCRIPTION
Moved from "pinned" branch to "main", as the LLM.swift package now appears to contain a specific pre-compiled LLM.cpp framework as part of it (rather than linking to the LLM.cpp repo as a dependency, which has since been renamed and broken the "pinned" branch).
